### PR TITLE
Fix incorrect parsing of timestamp in `qbt server log` command

### DIFF
--- a/src/QBittorrent.CommandLineInterface/Commands/ServerCommand.cs
+++ b/src/QBittorrent.CommandLineInterface/Commands/ServerCommand.cs
@@ -61,7 +61,7 @@ namespace QBittorrent.CommandLineInterface.Commands
                             break;
                     }
 
-                    var time = DateTimeOffset.FromUnixTimeMilliseconds(entry.Timestamp).ToString("s").Replace("T", " ");
+                    var time = DateTimeOffset.FromUnixTimeSeconds(entry.Timestamp).ToString("s").Replace("T", " ");
                     console.WriteColored($" {entry.Id:D6} {time} ", timestamp.fg, timestamp.bg);
                     console.WriteLineColored(entry.Message, message.fg, message.bg);
                 }


### PR DESCRIPTION
Use FromUnixTimeSeconds instead of FromUnixTimeMilliseconds for command `qbt server log` which returned incorrect date.

Fixes #78

EDIT: from official doc, switched from milliseconds to seconds in v4.5.0